### PR TITLE
default 256 bit mnemonic (24 words)

### DIFF
--- a/__tests__/unit/hd-segwit-bech32-wallet.test.js
+++ b/__tests__/unit/hd-segwit-bech32-wallet.test.js
@@ -62,7 +62,7 @@ describe('Bech32 Segwit HD (BIP84)', () => {
     for (let c = 0; c < 1000; c++) {
       await hd.generate();
       const secret = hd.getSecret();
-      assert.strictEqual(secret.split(' ').length, 12);
+      assert.strictEqual(secret.split(' ').length, 24);
       if (hashmap[secret]) {
         throw new Error('Duplicate secret generated!');
       }

--- a/src/wallet/abstract-hd-electrum-wallet.js
+++ b/src/wallet/abstract-hd-electrum-wallet.js
@@ -68,7 +68,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
   }
 
   async generate() {
-    const buf = await randomBytes(16);
+    const buf = await randomBytes(32);
     this.secret = bip39.entropyToMnemonic(buf.toString('hex'));
   }
 


### PR DESCRIPTION
Although it is true that Bitcoin's security model [aims to require an attacker to perform 2^128 guesses to find a private key](https://bitcoin.stackexchange.com/questions/72612/bip32-recommends-a-256-bit-seed-why-do-most-bitcoin-wallets-only-use-a-128-bit/75588#75588), and as such BIP32 requires mnemonics/private keys to possess _at least_ 128 bits of entropy, this is only a minimum threshold.

In practice, there is no guarantee that the method used to obtain entropy ('randomBytes` in this case) is 100% efficient.

Of course, Photon effectively generates hot wallet so there are lots of other security considerations aside from the entropy of the private keys, but in my view we should aim to ensure that the quality of entropy provided by `randomBytes` is not the lowest hanging fruit, by increasing the default mnemonic entropy to 256 bits.

I think the 'defence in depth' principle that Pieter Wuille mentions above is a good primitive to consider here, and I'd argue that we should not be operating at minimum thresholds when it comes to security.

As discussed elsewhere, this does come with an associated convenience tradeoff in that users must record 24 word mnemonics instead of 12 words. But this is already a de-facto industry standard which relevant users are accustomed to (and is in practice little more effort). In addition, Photon offers its in-built encrypted cloud backup option, where this tradeoff is obviously not relevant. 

I consider the manual seed backup option an alternative primarily appealing/relevant for non-beginners who:

1) practice more proficient and rigorous security
2) are more dedicated towards and aware of the importance of Bitcoin security best practices

and thus, the 12 -> 24 word shift should not come as a concern for these individuals.